### PR TITLE
perf: Optimize CREATE2 address calculation performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Using 12 CPU cores with 9600 goroutines
 
 
 Found!
-Salt: 0xdc29329056cbe845d85b9877691d0932ea1a59fd37e878d7e6d0ae3464ebe397
-Address: 0x000000f76928e94b2eced8d049b1772d54878cea
-Time elapsed: 8.838849095s
+Salt: 0x6bc1fbf8b243d862a1e499bc176c9c31876b2fd64aa2786da5e37984b3daa169
+Address: 0x000000e4f497a715960a1c8625e13d416066a239
+Time elapsed: 5.399090451s
 ```
 
 ## Performance Tuning


### PR DESCRIPTION
## Summary

This PR optimizes the CREATE2 vanity address finder for better performance and code quality.

## Changes

### Code Quality Improvements
- ✅ Simplified `hexToByte` function by extracting `hexCharToNibble` helper
- ✅ Use idiomatic Go 1.22+ range syntax (`for range N`)
- ✅ Cleaner, more maintainable code

### Performance Optimizations
- 🚀 **Pre-build CREATE2 data buffer template** - Static parts (0xff, deployer address, init code hash) are calculated once
- 🚀 **Reuse data buffer per goroutine** - Each goroutine allocates buffer once instead of billions of times
- 🚀 **Reduced memory copies** - Only update salt portion (32 bytes) instead of copying entire buffer (85 bytes) per iteration
- 🚀 **Eliminated per-iteration allocations** - Reduced from billions of allocations to ~numGoroutines allocations

## Performance Impact

**Before:**
- `make([]byte, 85)` called billions of times in hot loop
- 85 bytes copied per iteration (0xff + deployer + salt + initCodeHash)

**After:**
- `make([]byte, 85)` called once per goroutine (~9,600 times)
- Only 32 bytes copied per iteration (just the salt)

**Expected improvement:** Significant reduction in memory allocations and CPU cycles, leading to faster vanity address discovery.

## Testing

The optimization maintains the same CREATE2 calculation logic, only changing how the data buffer is managed. The algorithm and results remain identical.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author