### PR TITLE
Add Makefile with build optimizations and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Binary output
+pretty-ethereum-address

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.PHONY: build clean run install test help
+
+# Binary name
+BINARY_NAME=pretty-ethereum-address
+
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+
+# Build flags for optimization
+LDFLAGS=-ldflags="-s -w"
+GCFLAGS=-gcflags="-l=4"
+
+# Default target
+all: build
+
+## build: Build the binary with optimizations for speed
+build:
+	@echo "Building optimized binary..."
+	GOPROXY=https://proxy.golang.org,direct $(GOBUILD) $(LDFLAGS) $(GCFLAGS) -o $(BINARY_NAME) -v
+
+## build-debug: Build the binary with debug symbols
+build-debug:
+	@echo "Building debug binary..."
+	GOPROXY=https://proxy.golang.org,direct $(GOBUILD) -o $(BINARY_NAME) -v
+
+## clean: Remove build artifacts
+clean:
+	@echo "Cleaning..."
+	$(GOCLEAN)
+	rm -f $(BINARY_NAME)
+	rm -rf dist/
+
+## run: Build and run the application
+run: build
+	@echo "Running..."
+	./$(BINARY_NAME)
+
+## install: Install dependencies
+install:
+	@echo "Installing dependencies..."
+	GOPROXY=https://proxy.golang.org,direct $(GOMOD) download
+	GOPROXY=https://proxy.golang.org,direct $(GOMOD) tidy
+
+## test: Run tests
+test:
+	@echo "Running tests..."
+	$(GOTEST) -v ./...
+
+## bench: Run benchmarks
+bench:
+	@echo "Running benchmarks..."
+	$(GOTEST) -bench=. -benchmem ./...
+
+## deps: Download and verify dependencies
+deps:
+	@echo "Downloading dependencies..."
+	GOPROXY=https://proxy.golang.org,direct $(GOMOD) download
+	@echo "Verifying dependencies..."
+	$(GOMOD) verify
+
+## tidy: Tidy up go.mod and go.sum
+tidy:
+	@echo "Tidying up dependencies..."
+	$(GOMOD) tidy
+
+## help: Show this help message
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@grep -E '^## ' Makefile | sed 's/## /  /'
+


### PR DESCRIPTION
## Changes

- Add Makefile with optimized build flags for maximum execution speed
  - `-ldflags="-s -w"`: Strip debug symbols and symbol tables
  - `-gcflags="-l=4"`: Maximum inlining level for better performance
- Include common targets: `build`, `clean`, `run`, `install`, `test`, `bench`, `deps`, `tidy`, `help`
- Add binary name to `.gitignore` to prevent committing build artifacts

## Usage

```bash
make build    # Build optimized binary
make run      # Build and run
make help     # Show all available commands
```

## Benefits

- Faster execution speed through compiler optimizations
- Smaller binary size (stripped symbols)
- Consistent build process across environments
- Easy-to-use build commands

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author