### PR TITLE
chore: Rename project to Vaneth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build build-gpu clean run run-gpu install test help list-gpus
 
 # Binary name
-BINARY_NAME=pretty-ethereum-address
+BINARY_NAME=vaneth
 
 # Go parameters
 GOCMD=go
@@ -97,6 +97,6 @@ help:
 	@echo "  Tested with: AMD Radeon Pro 555X"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make build-gpu && ./pretty-ethereum-address --list-gpus"
+	@echo "  make build-gpu && ./vaneth --list-gpus"
 	@echo "  make run-gpu"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pretty-ethereum-address
+# Vaneth - Ethereum Vanity Address Miner ⛏️
 
-Generate vanity Ethereum contract addresses using CREATE2 opcode by finding the perfect salt.
+> GPU-accelerated CREATE2 vanity address miner for Ethereum using [Solady CREATE2 Factory](https://github.com/Vectorized/solady)
 
 ## Overview
 
@@ -26,8 +26,8 @@ address = keccak256(0xff ++ deployer_address ++ salt ++ keccak256(init_code))[12
 ### Standard Build (CPU only)
 
 ```bash
-git clone https://github.com/hadv/pretty-ethereum-address.git
-cd pretty-ethereum-address
+git clone https://github.com/hadv/vaneth.git
+cd vaneth
 go build
 ```
 
@@ -70,7 +70,7 @@ The init code hash is the keccak256 hash of your contract's creation bytecode. Y
 #### 3. Run the Program
 
 ```bash
-./pretty-ethereum-address
+./vaneth
 ```
 
 #### 4. Example Output
@@ -143,7 +143,7 @@ GPU acceleration provides significantly faster mining by leveraging OpenCL on AM
 #### List Available GPUs
 
 ```bash
-./pretty-ethereum-address --list-gpus
+./vaneth --list-gpus
 ```
 
 Example output:
@@ -156,7 +156,7 @@ Available GPUs:
 #### Run with GPU
 
 ```bash
-./pretty-ethereum-address --gpu --gpu-device 1 \
+./vaneth --gpu --gpu-device 1 \
   -i 747dd63dfae991117debeb008f2fb0533bb59a6eee74ba0e197e21099d034c7a \
   -s 0x18Ee4C040568238643C07e7aFd6c53efc196D26b \
   -p 0x0000


### PR DESCRIPTION
## Summary

Rename the project from `pretty-ethereum-address` to `Vaneth` (Vanity + Ethereum).

## Changes

### README.md
- New title: **Vaneth - Ethereum Vanity Address Miner ⛏️**
- New tagline with link to [Solady CREATE2 Factory](https://github.com/Vectorized/solady)
- Updated all binary references from `pretty-ethereum-address` to `vaneth`
- Updated clone URL to `https://github.com/hadv/vaneth.git`

### Makefile
- Updated `BINARY_NAME` to `vaneth`
- Updated help examples

## New Branding

```markdown
# Vaneth - Ethereum Vanity Address Miner ⛏️

> GPU-accelerated CREATE2 vanity address miner for Ethereum using Solady CREATE2 Factory
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author